### PR TITLE
Update profit calculation to reflect true profit after fees

### DIFF
--- a/MasterMerchant_DealCalc.lua
+++ b/MasterMerchant_DealCalc.lua
@@ -11,7 +11,7 @@ function MasterMerchant.CustomDealCalc(setPrice, salesCount, purchasePrice, stac
   local profit = -1
   if (setPrice) then
     local unitPrice = purchasePrice / stackCount
-    profit = (setPrice - unitPrice) * stackCount
+    profit = ((setPrice - unitPrice) - setPrice * 0.08) * stackCount
     margin = tonumber(string.format('%.2f', ((setPrice - unitPrice) / setPrice) * 100))
 
     if (margin >= MasterMerchant.systemSavedVariables.customDealBuyIt) then


### PR DESCRIPTION
This pull request updates the profit calculation to more accurately reflect true profit by subtracting the 8% total trading fees (1% listing + 7% guild cut) from the set price before multiplying by the stack count.

Before:
profit = (setPrice - unitPrice) * stackCount
After:
profit = ((setPrice - unitPrice) - setPrice * 0.08) * stackCount

This ensures that the displayed profit takes into account ESO’s 8% sales fee, providing users with a more accurate estimate of actual earnings.